### PR TITLE
fix-mobile-navbar-flash-at-startup

### DIFF
--- a/source/css/_partial/mobile.styl
+++ b/source/css/_partial/mobile.styl
@@ -1,17 +1,19 @@
-#mobile-nav
-  position: absolute
-  top: 0
-  left: 0
-  width: mobile-nav-width
-  height: 100%
-  background: color-mobile-nav-background
-  border-right: 1px solid #fff
+@media mq-mobile
+  #mobile-nav
+    position: absolute
+    top: 0
+    left: 0
+    width: mobile-nav-width
+    height: 100%
+    background: color-mobile-nav-background
+    border-right: 1px solid #fff
 
-.mobile-nav-link
-  display: block
-  color: color-grey
-  text-decoration: none
-  padding: 15px 20px
-  font-weight: bold
-  &:hover
-    color: #fff
+@media mq-mobile
+  .mobile-nav-link
+    display: block
+    color: color-grey
+    text-decoration: none
+    padding: 15px 20px
+    font-weight: bold
+    &:hover
+      color: #fff


### PR DESCRIPTION
When startup at PC browser in which the screen size is big enough, the mobile navbar will flash at one moment.
