### PR TITLE
fixed block quote's css

### DIFF
--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -78,10 +78,11 @@
     border-bottom: 1px solid color-border
     padding: 10px 0
   blockquote
-    font-family: font-serif
-    font-size: 1.4em
-    margin: line-height 20px
-    text-align: center
+    border: 1px solid #ddd;
+    border-left: 4px solid #ddd;
+    padding: 0 20px;
+    position: relative;
+    margin-left: 45px;
     footer
       font-size: font-size
       margin: line-height 0
@@ -90,6 +91,17 @@
         &:before
           content: "—"
           padding: 0 0.5em
+  blockquote:before
+    content: "\f10d";
+    position: absolute;
+    left: -45px;
+    top: 20px;
+    font-size: 25px;
+    font-family: FontAwesome;
+    width: 25px;
+    height: 25px;
+    text-align: center;
+    color: #ddd;
   .pullquote
     text-align: left
     width: 45%


### PR DESCRIPTION
The css of the 'blockquote' is not good, like this

![origin_blockquote](https://f.cloud.github.com/assets/3000006/2435905/d283ef6e-add1-11e3-94ed-5eae0c8b6afb.png)

after modified

![blockquote](https://f.cloud.github.com/assets/3000006/2435886/40b7f120-add1-11e3-8282-000cfb878b59.png)
