### PR TITLE
Updated Preview link to the correct preview site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A brand new default theme for [Hexo].
 
-- [Preview](http://zespia.tw/hexo-theme-landscape/)
+- [Preview](http://hexo.io/hexo-theme-landscape/)
 
 ## Installation
 


### PR DESCRIPTION
I am assuming the correct preview page for the layout is http://hexo.io/hexo-theme-landscape/ so have updated the link in the readme file.

This change should resolve https://github.com/hexojs/hexo-theme-landscape/issues/6
