### PR TITLE
Upgrade Google Analytics from ga.js to analytics.js

### DIFF
--- a/layout/_partial/google-analytics.ejs
+++ b/layout/_partial/google-analytics.ejs
@@ -1,13 +1,14 @@
 <% if (theme.google_analytics){ %>
+<!-- Google Analytics -->
 <script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', '<%= theme.google_analytics %>']);
-  _gaq.push(['_trackPageview']);
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
+ga('create', '<%= theme.google_analytics %>', 'auto');
+ga('send', 'pageview');
+
 </script>
+<!-- End Google Analytics -->
 <% } %>


### PR DESCRIPTION
Google is upgrading `Google Analytics` to [Universal Analytics](https://developers.google.com/analytics/devguides/collection/upgrade/guide#transfer), and  `ga.js` is going to retire.
So upgrade the code used in the theme
