### PR TITLE
Fix 1px white space in paginator on Chrome OS X

### DIFF
--- a/source/css/_partial/archive.styl
+++ b/source/css/_partial/archive.styl
@@ -57,6 +57,8 @@
   overflow: hidden
   a, span
     padding: 10px 20px
+    line-height: 1
+    height: 2ex
   a
     color: color-grey
     text-decoration: none


### PR DESCRIPTION
![before](https://cloud.githubusercontent.com/assets/3607926/3943953/14f2ff8a-25db-11e4-9af9-136f4782fc87.png)
The original styles of `#page-nav a, span` will cause 1px hover mismatch in Chrome of OS X, this could be fixed by adding unified line-height and height specification.
![after](https://cloud.githubusercontent.com/assets/3607926/3943958/536be6be-25db-11e4-8c65-3692374c7eb7.png)
