### PR TITLE
Ignore images within 'do not render' class

### DIFF
--- a/source/js/script.js
+++ b/source/js/script.js
@@ -89,6 +89,7 @@
   $('.article-entry').each(function(i){
     $(this).find('img').each(function(){
       if ($(this).parent().hasClass('fancybox')) return;
+      if ($(this).hasClass('fancybox-disabled')) return;
 
       var alt = this.alt;
 


### PR DESCRIPTION
img tags which has class="do-not-render" attribute would be ignored by the parser in case one would like to exclude particular images from Fancybox.
