### PR TITLE
Fix wrongly newlines after dashes.

### DIFF
--- a/source/css/_partial/sidebar.styl
+++ b/source/css/_partial/sidebar.styl
@@ -32,3 +32,4 @@ else
 .tagcloud
   a
     margin-right: 5px
+    display: inline-block


### PR DESCRIPTION
Fix wrongly newlines after dashes. For example, a tag "org-mode".
https://github.com/hexojs/hexo/issues/1092