### PR TITLE
Fixed issue preventing #main from resizing when sidebar:left and a post contains a code block

### DIFF
--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -72,8 +72,9 @@ if sidebar and sidebar isnt bottom
       column(main-column)
 
 if sidebar is left
-  #main
-    float: right
+  @media mq-normal
+    #main
+      float: right
 
 @import "_extend"
 @import "_partial/header"


### PR DESCRIPTION
 #main should only float: right for mq-normal if nav-links moved to left column

#main float:right breaks responsive design for mq-tablet and mq-mobile 
(when sidebar is moved to bottom)

Specifically, posts are stuck to the right edge of the screen. If any post contains a codeblock, #main does not resize and results in the screenshot below:
![screen shot 2015-05-29 at 10 16 19 pm](https://cloud.githubusercontent.com/assets/1541864/7895684/6716c35e-0650-11e5-81fa-b86f50b24862.png)

Fix #33 
