### PR TITLE
Add pagination bar in archives page

### DIFF
--- a/layout/_partial/archive.ejs
+++ b/layout/_partial/archive.ejs
@@ -2,14 +2,6 @@
   <% page.posts.each(function(post){ %>
     <%- partial('article', {post: post, index: true}) %>
   <% }) %>
-  <% if (page.total > 1){ %>
-    <nav id="page-nav">
-      <%- paginator({
-        prev_text: '&laquo; Prev',
-        next_text: 'Next &raquo;'
-      }) %>
-    </nav>
-  <% } %>
 <% } else { %>
   <% var last; %>
   <% page.posts.each(function(post, i){ %>
@@ -30,4 +22,12 @@
   <% if (page.posts.length){ %>
     </div></section>
   <% } %>
+<% } %>
+<% if (page.total > 1){ %>
+  <nav id="page-nav">
+    <%- paginator({
+      prev_text: '&laquo; Prev',
+      next_text: 'Next &raquo;'
+    }) %>
+  </nav>
 <% } %>


### PR DESCRIPTION
In archives page, there is no pagination bar when the page number is
bigger than the configuration value of per_page. This commit fix it.