### PR TITLE
use jsDelivr CDN, update jQuery & fancybox versions

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -13,12 +13,10 @@
   })();
 </script>
 <% } %>
-
-<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
-
 <% if (theme.fancybox){ %>
-  <%- css('fancybox/jquery.fancybox') %>
-  <%- js('fancybox/jquery.fancybox.pack') %>
-<% } %>
-
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/fancybox/2.1.5/jquery.fancybox.min.css" type="text/css">
+  <script src="//cdn.jsdelivr.net/g/jquery@2.1.4,fancybox@2.1.5"></script>
+<% } else {%>
+  <script src="//cdn.jsdelivr.net/jquery/2.1.4/jquery.min.js"></script>
+<% }%>
 <%- js('js/script') %>


### PR DESCRIPTION
I'm a bit biased since I volunteer for jsDelivr :)  Here are the advantages vs `ajax.googleapis.com`
+ can [collate all JS or CSS](https://github.com/jsdelivr/jsdelivr#load-multiple-files-with-single-http-request) into single file & HTTP request (slightly better net compression also).  The combined file is cached in the POP after 5+ calls.
+ much better performance in [China](http://www.jsdelivr.com/features/network-map)

The chance of a browser's cache has `//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js` is very slim.
Works with my site, but I don't use jQuery of anything else by FancyBox.

jsDelivr also allows [version auto-updating](https://github.com/jsdelivr/jsdelivr#version-aliasing), but I personally don't recommend that past minor updates.  (eg `jquery@2.1,fancybox@2.1` will serve jQuery 2.1.5 & FancyBox v2.1.9 if/when available.)

According to my brief tests here in Denver, speed is about the same for a website I'm working on, even though Google has a POP inside my city, & jsDelivr does not yet (will sometime).  Could be a more improvement gap if I [maxed out origin HTTP requests](http://tombyrer.github.io/slideshow-improving_load_times_with_cdns/#Browsers_HTTP_Connections) (eg had lots of pictures).

Thank you for all your hard work!