### PR TITLE
+ switch for font loading

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -28,7 +28,9 @@
   <% if (theme.favicon){ %>
     <link rel="icon" href="<%- theme.favicon %>">
   <% } %>
-  <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
+  <% if (config.highlight.enable){ %>
+    <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
+  <% } %>
   <%- css('css/style') %>
   <%- partial('google-analytics') %>
 </head>


### PR DESCRIPTION
I assume `Source Code Pro` is for the code highlighting?  So if `highlight:  enable: false` in `_config.yml`, then the unneeded font will not be loaded.  Saves some bandwidth.

If you wish, I can also switch to [jsDelivr CDN](https://github.com/hexojs/hexo-theme-landscape/pull/46) for better performance in China.