### PR TITLE
Add english translation

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -1,0 +1,19 @@
+categories: Categories
+search: Search
+tags: Tags
+tagcloud: Tag Cloud
+tweets: Tweets
+prev: Prev
+next: Next
+comment: Comments
+archive_a: Archives
+archive_b: "Archives: %s"
+page: Page %d
+recent_posts: Recent Posts
+newer: Newer
+older: Older
+share: Share
+powered_by: Powered by
+rss_feed: RSS Feed
+category: Category
+tag: Tag


### PR DESCRIPTION
This PR adds a translation file for English. I am using this theme for my blog, and I had to add `en.yml` file in order to get the English translation to work for this theme. By default the Chinese translation was showing for me. Adding the English translation file fixed the issue.