### PR TITLE
use system-ui font for font-sans

### DIFF
--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -19,7 +19,10 @@ color-pinterest = #cb2027
 color-google = #dd4b39
 
 // Fonts
-font-sans = "Helvetica Neue", Helvetica, Arial, sans-serif
+font-sans = -apple-system, BlinkMacSystemFont,
+    "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
+    "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif
 font-serif = Georgia, "Times New Roman", serif
 font-mono = "Source Code Pro", Consolas, Monaco, Menlo, Consolas, monospace
 font-icon = FontAwesome


### PR DESCRIPTION
see https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide for the implementation details.

Signed-off-by: J Huang <i@jhuang.me>