### PR TITLE
Fixed text for previous and next page buttons

### DIFF
--- a/layout/_partial/archive.ejs
+++ b/layout/_partial/archive.ejs
@@ -25,7 +25,7 @@
 <% } %>
 <% if (page.total > 1){ %>
   <nav id="page-nav">
-    <% var prev_text = "&laquo; " + __('prev');var next_text = __('next') + " &raquo;"%>
+    <% var prev_text = "&laquo; Prev";var next_text = "Next &raquo;"%>
     <%- paginator({
       prev_text: prev_text,
       next_text: next_text


### PR DESCRIPTION
I think the previous '_('prev')' was done in error.  I think this looks better.

Jordan
