### PR TITLE
Fix links to the feed

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -23,7 +23,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <%- open_graph({twitter_id: theme.twitter, google_plus: theme.google_plus, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id}) %>
   <% if (theme.rss){ %>
-    <link rel="alternate" href="<%- theme.rss %>" title="<%= config.title %>" type="application/atom+xml">
+    <link rel="alternate" href="<%= url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml">
   <% } %>
   <% if (theme.favicon){ %>
     <link rel="icon" href="<%- theme.favicon %>">

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -20,7 +20,7 @@
       </nav>
       <nav id="sub-nav">
         <% if (theme.rss){ %>
-          <a id="nav-rss-link" class="nav-icon" href="<%- theme.rss %>" title="<%= __('rss_feed') %>"></a>
+          <a id="nav-rss-link" class="nav-icon" href="<%-= url_for(theme.rss) %>" title="<%= __('rss_feed') %>"></a>
         <% } %>
         <a id="nav-search-btn" class="nav-icon" title="<%= __('search') %>"></a>
       </nav>


### PR DESCRIPTION
This PR fixes an issue that links to the feed are broken unless the root is `/`.

For example, if the url is `example.com`, the root is `/child/` and the path to feed is `/atom.xml`, Hexo generates links ``example.com/atom.xml`` which is incorrect; ``example.com/child/atom.xml`` is corrent.
