### PR TITLE
Allow user to add additional style sheets to theme.

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -32,5 +32,6 @@
   <% if (config.highlight.enable){ %>
     <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
   <% } %>
-  <%- css('css/style') %>
+  <!-- Pull style sheets from theme and users site -->
+  <%- fileLister('css/', '.styl', function(file) {return '<link rel="stylesheet" href="css/'+ file.replace('.styl', '.css') + '">';}) %>
 </head>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -33,5 +33,5 @@
     <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
   <% } %>
   <!-- Pull style sheets from theme and users site -->
-  <%- fileLister('css/', '.styl', function(file) {return '<link rel="stylesheet" href="css/'+ file.replace('.styl', '.css') + '">';}) %>
+  <%- fileLister('css/', '.styl', function(file) {return '<link rel="stylesheet" href="/css/'+ file.replace('.styl', '.css') + '">';}) %>
 </head>

--- a/scripts/fileLister.js
+++ b/scripts/fileLister.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+* Syntax:
+*   <%- fileLister path extension action %>
+*
+*   List files from theme and user site.
+*   It looks in:
+*       /themes/<themeName>/source/<path>
+*       /source/<path>
+*
+*   For files that end with <extension>
+*   Filtering out any file that start with '_'
+*
+*   It then applies the function `action(file)` for every file that matches.
+*
+*   Example usage is to combine theme and user style sheets into header file.
+*/
+
+hexo.extend.helper.register('fileLister', function(path, extension, action) {
+
+    var fs = require("fs");
+
+    var sitePath    = "." + this.config.root + "/source/" + path;
+    var siteResult  = fs.readdirSync(sitePath);
+
+    var themePath   = "." + this.config.root + "/themes/" + this.config.theme + "/source/" + path;
+    var themeResult = fs.readdirSync(themePath);
+
+    /*
+     * Combine results from theme and user site.
+     */
+    var list = themeResult.concat(siteResult).filter(file => file.endsWith(extension) && !file.startsWith("_"));
+    var text = list.map(action);
+    var output = text.join("\n");
+    return output;
+});
+
+


### PR DESCRIPTION
    This change scans the directories
        theme/<themename>/source/css
        source/css

    For files with the extension ".style" then places all found styles in the header.
    This means if the site owner adds a style file it will automatically be incorporated
    into the site.

    1: Added a script that scans the theme and user site (for a particular path).
       This scripted is created as a hexo helper.
        scripts/fileLister.js
    2: Modified layout/_partial/head.ejs to use <%- fileLister() %> to generate style sheets.