### PR TITLE
remove hexo_version missing function

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -22,7 +22,6 @@
   %>
   <title><% if (title){ %><%= title %> | <% } %><%= config.title %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="generator" content="Hexo <%= hexo_version() %>">
   <%- open_graph({twitter_id: theme.twitter, google_plus: theme.google_plus, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id}) %>
   <% if (theme.rss){ %>
     <link rel="alternate" href="<%= url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml">


### PR DESCRIPTION
## What does it do?

It removes one line containing `hexo_version()` which does not exist.

## How to test

```sh
mkdir landscape-test
cd landscape-test
hexo init
rm -rf themes/landscape
git clone -b remove-hexo-version-bug https://github.com/tcrowe/hexo-theme-landscape.git themes/landscape
hexo serve --debug
open http://127.0.0.1:4000
```
