### PR TITLE
Fix closing "html" tag appears twice.

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<html>
 <head>
   <meta charset="utf-8">
   <%- partial('google-analytics') %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+<html>
 <%- partial('_partial/head') %>
 <body>
   <div id="container">


### PR DESCRIPTION
The result of `hexo g` immediately after executing `hexo init` is as follows.

```
$ hexo g
$ grep -A 2 -B 2 '</html>' public/index.html
  <link rel="stylesheet" href="/css/style.css">
</head>
</html>
<body>
  <div id="container">
--
--
  </div>
</body>
</html>
```

Tag `</html>` appears twice. The first appears before opening `<body>` tag.