### PR TITLE
Include article title in tweets text when sharing with Twitter

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -23,7 +23,7 @@
       <% } %>
     </div>
     <footer class="article-footer">
-      <a data-url="<%- post.permalink %>" data-id="<%= post._id %>" class="article-share-link"><%= __('share') %></a>
+      <a data-url="<%- post.permalink %>" data-id="<%= post._id %>" data-title="<%= post.title %>" class="article-share-link"><%= __('share') %></a>
       <% if (post.comments && config.disqus_shortname){ %>
         <a href="<%- post.permalink %>#disqus_thread" class="article-comment-link"><%= __('comment') %></a>
       <% } %>

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -41,6 +41,7 @@
       url = $this.attr('data-url'),
       encodedUrl = encodeURIComponent(url),
       id = 'article-share-box-' + $this.attr('data-id'),
+      title = $this.attr('data-title'),
       offset = $this.offset();
 
     if ($('#' + id).length){
@@ -55,7 +56,7 @@
         '<div id="' + id + '" class="article-share-box">',
           '<input class="article-share-input" value="' + url + '">',
           '<div class="article-share-links">',
-            '<a href="https://twitter.com/intent/tweet?url=' + encodedUrl + '" class="article-share-twitter" target="_blank" title="Twitter"></a>',
+            '<a href="https://twitter.com/intent/tweet?text=' + encodeURIComponent(title) + '&url=' + encodedUrl + '" class="article-share-twitter" target="_blank" title="Twitter"></a>',
             '<a href="https://www.facebook.com/sharer.php?u=' + encodedUrl + '" class="article-share-facebook" target="_blank" title="Facebook"></a>',
             '<a href="http://pinterest.com/pin/create/button/?url=' + encodedUrl + '" class="article-share-pinterest" target="_blank" title="Pinterest"></a>',
             '<a href="https://plus.google.com/share?url=' + encodedUrl + '" class="article-share-google" target="_blank" title="Google+"></a>',


### PR DESCRIPTION
This pull request adds functionality to the Twitter share on the SNS share button below the article.

This pull request will include the article title in the tweet when sharing the article on Twitter.
Currently, only the URL is included in the tweet, not the title of the article.
When the tweet template is displayed, it would be nice to include both the article title and the URL.

Also, when the tweet template is displayed, the article title will be in the selected state. This is a Twitter specification.
It is a function that allows users to easily delete the text written in the template (here, the title of the article).

Please refer to here also about the function of Twitter.
https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/overview

Thank you!