### PR TITLE
Remove Google+ shared link button because the Google+ service has ended

### DIFF
--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -294,14 +294,6 @@ $article-share-link
     background: color-pinterest
     text-shadow: 0 1px darken(color-pinterest, 20%)
 
-.article-share-google
-  @extend $article-share-link
-  &:before
-    content: "\f0d5"
-  &:hover
-    background: color-google
-    text-shadow: 0 1px darken(color-google, 20%)
-
 .article-share-linkedin
   @extend $article-share-link
   &:before

--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -16,7 +16,6 @@ color-mobile-nav-background = #191919
 color-twitter = #00aced
 color-facebook = #3b5998
 color-pinterest = #cb2027
-color-google = #dd4b39
 color-linkedin = #0077B5
 
 // Fonts

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -58,7 +58,6 @@
             '<a href="https://twitter.com/intent/tweet?url=' + encodedUrl + '" class="article-share-twitter" target="_blank" title="Twitter"></a>',
             '<a href="https://www.facebook.com/sharer.php?u=' + encodedUrl + '" class="article-share-facebook" target="_blank" title="Facebook"></a>',
             '<a href="http://pinterest.com/pin/create/button/?url=' + encodedUrl + '" class="article-share-pinterest" target="_blank" title="Pinterest"></a>',
-            '<a href="https://plus.google.com/share?url=' + encodedUrl + '" class="article-share-google" target="_blank" title="Google+"></a>',
             '<a href="https://www.linkedin.com/shareArticle?mini=true&url=' + encodedUrl + '" class="article-share-linkedin" target="_blank" title="LinkedIn"></a>',
           '</div>',
         '</div>'


### PR DESCRIPTION
This pull request removes "Google+" from the article share button.

The Google+ service ended in April 2019. Therefore, it is necessary to delete it from the share button of the article.

Currently, when Google + 's share button is clicked, the Google+ end announcement page is displayed. Therefore, this button will not be used. So pull request for deletion.

e.g. URL of Google+ share from the demo site of this theme
https://plus.google.com/up/?continue=https://plus.google.com/share?url%3Dhttps://hexo.io/hexo-theme-landscape/hexo-theme-landscape/2013/12/24/long-title/