### PR TITLE
Remove Google+ OGP header tags because the Google+ service has ended

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ widgets:
 google_analytics:
 favicon: /favicon.png
 twitter:
-google_plus:
 ```
 
 - **menu** - Navigation menu
@@ -63,7 +62,6 @@ google_plus:
 - **google_analytics** - Google Analytics ID
 - **favicon** - Favicon path
 - **twitter** - Twiiter ID
-- **google_plus** - Google+ ID
 
 ## Features
 

--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,6 @@ google_analytics:
 gauges_analytics:
 favicon: /favicon.png
 twitter:
-google_plus:
 fb_admins:
 fb_app_id:
 

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -20,7 +20,7 @@
   %>
   <title><% if (title){ %><%= title %> | <% } %><%= config.title %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <%- open_graph({twitter_id: theme.twitter, google_plus: theme.google_plus, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id}) %>
+  <%- open_graph({twitter_id: theme.twitter, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id}) %>
   <% if (theme.rss){ %>
     <link rel="alternate" href="<%= url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml">
   <% } %>


### PR DESCRIPTION
This pull request removes "Google+" from the OGP header tags.

The Google+ service ended in April 2019. Therefore, it is necessary to delete it from the share button of the article.
