### PR TITLE
Set the banner image path as a configuration file (resolve #106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ menu:
   Home: /
   Archives: /archives
 rss: /atom.xml
+banner: images/banner.jpg
 
 # Content
 excerpt_link: Read More
@@ -56,6 +57,7 @@ google_plus:
 
 - **menu** - Navigation menu
 - **rss** - RSS link
+- **banner** - Path of title banner image of page top
 - **excerpt_link** - "Read More" link at the bottom of excerpted articles. `false` to hide the link.
 - **fancybox** - Enable [Fancybox]
 - **sidebar** - Sidebar style. You can choose `left`, `right`, `bottom` or `false`.

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ menu:
   Home: /
   Archives: /archives
 rss: /atom.xml
+banner: "images/banner.jpg"
 
 # Content
 excerpt_link: Read More

--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -37,7 +37,7 @@ line-height-title = 1.1em
 logo-size = 40px
 subtitle-size = 16px
 banner-height = 300px
-banner-url = "images/banner.jpg"
+banner-url = hexo-config("banner")
 
 sidebar = hexo-config("sidebar")
 


### PR DESCRIPTION
This pull request resolves Issues #106.
Set the banner image path at the top of the page from the configuration file.

As discussed in Issues #106, it may be better not to make binary changes to the default banner image in user's repository.

Create a new banner image file (e.g., in the `assets` directory) and specify its path from the configuration file.

Thank you.