### PR TITLE
docs(readme): shallow clone theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A brand new default theme for [Hexo].
 ### Install
 
 ``` bash
-$ git clone https://github.com/hexojs/hexo-theme-landscape.git themes/landscape
+$ git clone --depth 1 https://github.com/hexojs/hexo-theme-landscape themes/landscape
 ```
 
 **Landscape requires Hexo 2.4 and above.** If you would like to enable the RSS, the [hexo-generate-feed] plugin is also required.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ $ git clone https://github.com/hexojs/hexo-theme-landscape.git themes/landscape
 
 Modify `theme` setting in `_config.yml` to `landscape`.
 
+``` diff
+_config.yml
+- theme: some-theme
++ theme: landscape
+```
+
 ### Update
 
 ``` bash


### PR DESCRIPTION
so that commit history is not downloaded to save some space.