### PR TITLE
fix(seo): use valid schema and add microformat

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -1,4 +1,4 @@
-<article id="<%= post.layout %>-<%= post.slug %>" class="article article-type-<%= post.layout %>" itemscope itemprop="blogPost">
+<article id="<%= post.layout %>-<%= post.slug %>" class="h-entry article article-type-<%= post.layout %>" itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
   <div class="article-meta">
     <%- partial('post/date', {class_name: 'article-date', date_format: null}) %>
     <%- partial('post/category') %>
@@ -7,10 +7,10 @@
     <%- partial('post/gallery') %>
     <% if (post.link || post.title){ %>
       <header class="article-header">
-        <%- partial('post/title', {class_name: 'article-title'}) %>
+        <%- partial('post/title', {class_name: 'p-name article-title'}) %>
       </header>
     <% } %>
-    <div class="article-entry" itemprop="articleBody">
+    <div class="e-content article-entry" itemprop="articleBody">
       <% if (post.excerpt && index){ %>
         <%- post.excerpt %>
         <% if (theme.excerpt_link){ %>

--- a/layout/_partial/post/date.ejs
+++ b/layout/_partial/post/date.ejs
@@ -1,3 +1,3 @@
 <a href="<%- url_for(post.path) %>" class="<%= class_name %>">
-  <time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date, date_format) %></time>
+  <time class="dt-published" datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date, date_format) %></time>
 </a>

--- a/layout/_partial/post/title.ejs
+++ b/layout/_partial/post/title.ejs
@@ -8,7 +8,7 @@
       <a class="<%= class_name %>" href="<%- url_for(post.path) %>"><%= post.title %></a>
     </h1>
   <% } else { %>
-    <h1 class="<%= class_name %>" itemprop="name">
+    <h1 class="<%= class_name %>" itemprop="headline name">
       <%= post.title %>
     </h1>
   <% } %>


### PR DESCRIPTION
This fix the `Unspecified type` schema issue identified by [Google](https://search.google.com/structured-data/testing-tool/).

`headline` class is only added to post title in an article, not archive/index.

Add [h-entry](http://microformats.org/wiki/h-entry) Microformat.

schema fix is based on [this example](https://github.com/philwareham/schema-microdata-examples/blob/master/blog.html).