### PR TITLE
fix(highlight-css): load css from jsdelivr cdn

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -28,7 +28,7 @@
     <link rel="icon" href="<%- theme.favicon %>">
   <% } %>
   <% if (config.highlight.enable){ %>
-    <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
+    <%- css('https://cdn.jsdelivr.net/npm/typeface-source-code-pro@0.0.71/index.min.css') %>
   <% } %>
   <%- css('css/style') %>
   <% if (theme.fancybox){ %>


### PR DESCRIPTION
similar to https://github.com/hexojs/site/pull/1054, which is also load from https://github.com/KyleAMathews/typefaces.

There is official version https://cdn.jsdelivr.net/npm/source-code-pro@2.30.2/source-code-pro.css which is loaded from https://github.com/adobe-fonts/source-code-pro, but the font assets are bigger than google's.

https://github.com/KyleAMathews/typefaces is essentially a mirror of google fonts.