### PR TITLE
refactor: better usage of fragment_cache

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -13,34 +13,41 @@
 </script>
 <% } %>
 
-<%- js('js/jquery-3.4.1.min.js') %>
+<%- fragment_cache('after_footer_custom', () => {
+    let html = ''
+    html += js('js/jquery-3.4.1.min.js');
+    if (theme.fancybox) {
+        html += js('fancybox/jquery.fancybox.min.js')
+    }
 
-<% if (theme.fancybox){ %>
-  <%- js('fancybox/jquery.fancybox.min.js') %>
-<% } %>
+    html += js('js/script');
+    html += partial('gauges-analytics')
 
-<%- js('js/script') %>
-<%- partial('gauges-analytics') %>
+    if (theme.valine.enable && theme.valine.appId && theme.valine.appKey) {
+        html += js('https://cdn.jsdelivr.net/npm/valine@1.3.10/dist/Valine.min.js');
 
-<% if(theme.valine.enable && theme.valine.appId && theme.valine.appKey){ %>
-  <%- js('https://cdn.jsdelivr.net/npm/valine@1.3.10/dist/Valine.min.js') %>
-<script>
-    var GUEST_INFO = ['nick','mail','link'];
-    var guest_info = '<%= theme.valine.guest_info %>'.split(',').filter(function(item){
-        return GUEST_INFO.indexOf(item) > -1
-    });
-    var notify = '<%= theme.valine.notify %>' == true;
-    var verify = '<%= theme.valine.verify %>' == true;
-    new Valine({
-        el: '.vcomment',
-        notify: notify,
-        verify: verify,
-        appId: "<%= theme.valine.appId %>",
-        appKey: "<%= theme.valine.appKey %>",
-        placeholder: "<%= theme.valine.placeholder %>",
-        pageSize:'<%= theme.valine.pageSize %>',
-        avatar:'<%= theme.valine.avatar %>',
-        lang:'<%= theme.valine.lang %>'
-    });
-</script>
-<% } %>
+        html += `
+        <script>
+            var GUEST_INFO = ['nick','mail','link'];
+            var guest_info = '${theme.valine.guest_info}'.split(',').filter(function(item){
+                return GUEST_INFO.indexOf(item) > -1
+            });
+            var notify = '${theme.valine.notify}' == true;
+            var verify = '${theme.valine.verify}' == true;
+            new Valine({
+                el: '.vcomment',
+                notify: notify,
+                verify: verify,
+                appId: "${theme.valine.appId}",
+                appKey: "${theme.valine.appKey}",
+                placeholder: "${theme.valine.placeholder}",
+                pageSize:'${theme.valine.pageSize}',
+                avatar:'${theme.valine.avatar}',
+                lang:'${theme.valine.lang}'
+            });
+        </script>
+        `
+    }
+
+    return html
+}) %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -7,9 +7,18 @@
       <%- partial('_partial/header', null, {cache: !config.relative_link}) %>
       <div class="outer">
         <section id="main"><%- body %></section>
-        <% if (theme.sidebar && theme.sidebar !== 'bottom'){ %>
-          <%- partial('_partial/sidebar', null, {cache: !config.relative_link}) %>
+
+        <% if (!config.relative_link) { %>
+            <%- fragment_cache('sidebar', function() {
+                if (theme.sidebar && theme.sidebar !== 'bottom') return partial('_partial/sidebar');
+                return '';
+            }) %>
+        <% } else { %>
+            <% if (theme.sidebar && theme.sidebar !== 'bottom') { %>
+                <%- partial('_partial/sidebar') %>
+            <% } %>
         <% } %>
+
       </div>
       <%- partial('_partial/footer', null, {cache: !config.relative_link}) %>
     </div>


### PR DESCRIPTION
After have a close look at https://github.com/hexojs/hexo/issues/2164, I have realized something.

Although configuration file (both site's `_config.yml` and theme's `_config.yml`) is loaded only once, but the value has to be readed from parsed config (inside Locals) every time when meets in layout. So it is important to wrap config value inside fragment_cache.

I have ran through a benchmark with same setup I used in https://github.com/hexojs/hexo/issues/3663. Before https://github.com/hexojs/hexo-theme-landscape/pull/152/commits/c8d5d1628711a7d4bc8646becd9c4e58498ddfed, is takes about 6.16 seconds to generate a site with 300 posts, After https://github.com/hexojs/hexo-theme-landscape/pull/152/commits/c8d5d1628711a7d4bc8646becd9c4e58498ddfed, it drops to about 5.9 seconds, which is about 4% less.

This PR is a PoC that we should wrap `<%= config.xxx %>` or `<%= theme.xxx %>` inside fragment_cache as much as possible.