### PR TITLE
fix: HTML entities in paginator without escape

### DIFF
--- a/layout/_partial/archive.ejs
+++ b/layout/_partial/archive.ejs
@@ -28,7 +28,8 @@
     <% var prev_text = "&laquo; " + __('prev');var next_text = __('next') + " &raquo;"%>
     <%- paginator({
       prev_text: prev_text,
-      next_text: next_text
+      next_text: next_text,
+      escape: false
     }) %>
   </nav>
 <% } %>


### PR DESCRIPTION
pass `escape` option to paginatorHelper in `https://github.com/hexojs/hexo/blob/master/lib/plugins/helper/paginator.js`