### PR TITLE
Delete unneeded font-size: 1.4em for blockquote

### DIFF
--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -79,7 +79,6 @@
     padding: 10px 0
   blockquote
     font-family: font-serif
-    font-size: 1.4em
     margin: line-height 20px
     text-align: center
     footer


### PR DESCRIPTION
This makes `<blockquote>` text unnecessarily larger than the surrounding normal text.