### PR TITLE
css: pin footer to bottom of screen

### DIFF
--- a/source/css/_partial/footer.styl
+++ b/source/css/_partial/footer.styl
@@ -1,6 +1,6 @@
 #footer
   background: color-footer-background
-  padding: 50px 0
+  padding: footer-padding 0
   border-top: 1px solid color-border
   color: color-grey
   a

--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -46,6 +46,10 @@ article-padding = 20px
 mobile-nav-width = 280px
 main-column = 9
 sidebar-column = 3
+// Footer
+footer-padding = 50px
+// Total size of footer
+footer-height = 2*footer-padding + 38.33px
 
 if sidebar and sidebar isnt bottom
   _sidebar-column = sidebar-column

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -88,3 +88,7 @@ if sidebar is left
 
 if sidebar
   @import "_partial/sidebar"
+
+// pin the footer to the bottom of the screen even if content is small
+body > div#container > div#wrap > div.outer
+	min-height: s('calc(100vh - %s - %s)',banner-height, footer-height)


### PR DESCRIPTION
Depending on how little content there is on any given url the footer may end up right up next to the content halfway up the screen. This keeps the footer in place towards the bottom, footer-height needs to be adjusted with the exact value the footer represents.