### PR TITLE
Fix typo in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ widgets:
 - category
 - tag
 - tagcloud
-- archives
+- archive
 - recent_posts
 
 # Miscellaneous


### PR DESCRIPTION
I might be using hexo / landscape wrong (I only just started), but I installed hexo and landscape, then copied the config from the readme into my `_config.landscape.yml`, and I got the following error (this is the important part of the error I think):

```
/home/caj/files/reps/websites/hexo-blog/nonbinaryalgorithms/node_modules/hexo-theme-landscape/layout/_partial/sidebar.ejs:3
    1| <aside id="sidebar"<% if (theme.sidebar === 'bottom'){ %> class="outer"<% } %>>
    2|   <% theme.widgets.forEach(function(widget){ %>
 >> 3|     <%- partial('_widget/' + widget) %>
    4|   <% }) %>
    5| </aside>

Partial _widget/archives does not exist. (in _partial/sidebar.ejs)
```

When I had a look, there is no _widget/archives, but there is _widget/archive, and when I fixed that the page could then be built, and I had a working `archives` link.