### PR TITLE
Update fork-awesome to 1.2.0

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -37,6 +37,6 @@
     <%- css('fancybox/jquery.fancybox.min.css') %>
   <% } %>
   <% if (theme.links) {%>
-    <%- css('https://cdn.jsdelivr.net/npm/fork-awesome@1.1.7/css/fork-awesome.min.css') %>
+    <%- css('https://cdn.jsdelivr.net/npm/fork-awesome@1.2.0/css/fork-awesome.min.css') %>
   <% } %>
 </head>


### PR DESCRIPTION
Fork-Awesome has released 1.2.0 on Aug 2021, but we're still using 1.1.7 released 3 years ago.