### PR TITLE
Fix share icon size

### DIFF
--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -257,7 +257,7 @@ $article-share-link
   position: relative
   color: #999
   text-shadow: 0 1px #fff
-  &:before
+  .fa
     font-size: 20px
     absolute-center(@font-size)
     text-align: center


### PR DESCRIPTION
<img width="319" alt="Screenshot 2024-03-26 at 07 59 21" src="https://github.com/hexojs/hexo-theme-landscape/assets/939254/427dddb4-d702-4c3c-9575-2a50d371ae0f">

Introduced in https://github.com/hexojs/hexo-theme-landscape/commit/7dfe38c6e50b98ad63c51e24cca3f1caf8714870#diff-26213b4007aa6716fd661abe8c9923559eca40f37a5392bca85ccc0b3419389cR59