### PR TITLE
fork-awesome style tag should not be conditional anymore

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -36,7 +36,5 @@
   <% if (theme.fancybox){ %>
     <%- css('fancybox/jquery.fancybox.min.css') %>
   <% } %>
-  <% if (theme.links) {%>
-    <%- css('https://cdn.jsdelivr.net/npm/fork-awesome@1.2.0/css/fork-awesome.min.css') %>
-  <% } %>
+  <%- css('https://cdn.jsdelivr.net/npm/fork-awesome@1.2.0/css/fork-awesome.min.css') %>
 </head>


### PR DESCRIPTION
Since now the fork-awesome icons are being used for the mobile navigation toggle buttion, the inclusion of the fork-awesome should not be conditional. If not, the icon won't appear on mobile if you don't configure any links on the theme config, which, as far I as know, is not a required config item.