### PR TITLE
docs: update configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy preview site
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: [master]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -10,25 +10,25 @@ A brand new default theme for [Hexo].
 
 ### Install
 
-Local git install:
-
-``` bash
-$ git clone --depth 1 https://github.com/hexojs/hexo-theme-landscape themes/landscape
-```
-
-npm install:
+If you're using Hexo 5.0 or later, the simplest way to install is through npm:
 
 ```
 npm i hexo-theme-landscape
 ```
 
-**Landscape requires Hexo 2.4 and above.** If you would like to enable the RSS, the [hexo-generator-feed](https://github.com/hexojs/hexo-generator-feed) plugin is also required.
+Local git install:
+
+```bash
+git clone --depth 1 https://github.com/hexojs/hexo-theme-landscape themes/landscape
+```
+
+If you would like to enable the RSS, the [hexo-generator-feed](https://github.com/hexojs/hexo-generator-feed) plugin is also required.
 
 ### Enable
 
 Modify `theme` setting in `_config.yml` to `landscape`.
 
-``` diff
+```diff
 _config.yml
 - theme: some-theme
 + theme: landscape
@@ -36,14 +36,22 @@ _config.yml
 
 ### Update
 
-``` bash
+Install the latest version through npm:
+
+```sh
+npm install hexo-theme-landscape@latest
+```
+
+Or update to the latest master branch:
+
+```bash
 cd themes/landscape
 git pull
 ```
 
 ## Configuration
 
-The configuration file for this theme is the `_config.yml` file in the theme repository. As the default theme for Hexo, it is installed via npm during the `hexo init` site creation process, so it is generally located in the `node_modules/hexo-theme-landscape` directory. If you install it via `git clone` or similar methods, it might be located in the `themes/landscape` directory.
+The configuration file for the theme is `_config.yml` in the repository. As the default theme for Hexo, hexo-theme-landscape is installed via npm during the `hexo init` site creation process, so it is generally located in the `node_modules/hexo-theme-landscape` directory. If you install it via `git clone` or other methods, it might be located in the `themes/landscape` directory.
 
 It is important to note that to prevent your modifications to the theme configuration file from being lost or overwritten during theme upgrades, **we do not recommend directly modifying this default configuration file**. You can copy the theme's `_config.yml` to your blog's root directory as `_config.landscape.yml` and configure it according to the documentation of configuration options therein (see [Alternate Theme Config](https://hexo.io/docs/configuration#Alternate-Theme-Config)).
 
@@ -51,7 +59,7 @@ The following will also detail the usage of some options.
 
 ## Features
 
-### Fancybox
+### FancyBox
 
 Landscape uses [Fancybox] to showcase your photos. You can use Markdown syntax or fancybox tag plugin to add your photos.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Install the latest version through npm:
 npm install hexo-theme-landscape@latest
 ```
 
-Or update to the latest master branch:
+Or update to the latest master branch via git:
 
 ```bash
 cd themes/landscape

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you're using Hexo 5.0 or later, the simplest way to install is through npm:
 npm i hexo-theme-landscape
 ```
 
-Local git install:
+Install via git:
 
 ```bash
 git clone --depth 1 https://github.com/hexojs/hexo-theme-landscape themes/landscape

--- a/README.md
+++ b/README.md
@@ -43,61 +43,11 @@ git pull
 
 ## Configuration
 
-It is recommended not to modify `theme/landscape/_config.yml` but to use the `theme_config` section of `_config.yml` or to create `_config.landscape.yml` (see [Alternate Theme Config](https://hexo.io/docs/configuration#Alternate-Theme-Config)).
+The configuration file for this theme is the `_config.yml` file in the theme repository. As the default theme for Hexo, it is installed via npm during the `hexo init` site creation process, so it is generally located in the `node_modules/hexo-theme-landscape` directory. If you install it via `git clone` or similar methods, it might be located in the `themes/landscape` directory.
 
-``` yml
-# Header
-menu:
-  Home: /
-  Archives: /archives
-rss: /atom.xml
-banner: images/banner.jpg
-subtitle: This a subtitle
+It is important to note that to prevent your modifications to the theme configuration file from being lost or overwritten during theme upgrades, **we do not recommend directly modifying this default configuration file**. You can copy the theme's `_config.yml` to your blog's root directory as `_config.landscape.yml` and configure it according to the documentation of configuration options therein (see [Alternate Theme Config](https://hexo.io/docs/configuration#Alternate-Theme-Config)).
 
-# Content
-excerpt_link: Read More
-fancybox: true
-recent_posts_limits: 5
-# Footer
-copyright: |-
-  <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" /></a></br>
-  All website licensed under <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank">CC BY-NC-ND 4.0</a></br>
-
-# Sidebar
-sidebar: right
-widgets:
-- category
-- tag
-- tagcloud
-- archive
-- recent_posts
-
-# Miscellaneous
-google_analytics:
-favicon: /favicon.png
-twitter:
-
-# Header links
-# Each name must correspond to the icon name of Fork Awesome
-# https://forkaweso.me/Fork-Awesome/icons/
-#links:
-#  github: https://github.com/your_github_account
-#  twitter: https://twitter.com/your_twitter_account
-#  telegram: https://t.me/your_telegram_account
-```
-
-- **menu** - Navigation menu
-- **rss** - RSS link
-- **banner** - Path of title banner image of page top
-- **excerpt_link** - "Read More" link at the bottom of excerpted articles. `false` to hide the link.
-- **fancybox** - Enable [Fancybox]
-- **recent_posts_limits** - How many posts display in Home page.
-- **sidebar** - Sidebar style. You can choose `left`, `right`, `bottom` or `false`.
-- **widgets** - Widgets displaying in sidebar
-- **google_analytics** - Google Analytics ID
-- **favicon** - Favicon path
-- **twitter** - Twitter ID
-- **links** - Header links with icon, specified links will appear at the top right corner of the page
+The following will also detail the usage of some options.
 
 ## Features
 
@@ -129,8 +79,8 @@ All of them are enabled by default. You can edit them in `widget` setting.
 
 You can add links to the header area with icons.
 
-```
-social:
+```yml
+links:
   github: https://github.com/your_github_account
   twitter: https://twitter.com/your_twitter_account
   telegram: https://t.me/your_telegram_account

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,6 @@
+# ===============
 # Header
+# ===============
 # Navigation menu
 menu:
   Home: /
@@ -17,13 +19,17 @@ links:
 #  twitter: https://twitter.com/your_twitter_account
 #  telegram: https://t.me/your_telegram_account
 
+# ===============
 # Content
+# ===============
 # "Read More" link at the bottom of excerpted articles. `false` to hide the link.
 excerpt_link: Read More
 # Enable fancybox
 fancybox: true
 
+# ===============
 # Footer
+# ===============
 # Display copyright notice in footer. Please see https://creativecommons.org/choose/ and https://choosealicense.com/
 # You can use html like below.
 # copyright: |-
@@ -31,7 +37,9 @@ fancybox: true
 #   All website licensed under <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a></br>
 copyright:
 
+# ===============
 # Sidebar
+# ===============
 # Sidebar style. You can choose `left`, `right`, `bottom` or `false`.
 sidebar: right
 # Widgets displaying in sidebar
@@ -42,19 +50,17 @@ widgets:
 - archive
 - recent_posts
 
-# display widgets at the bottom of index pages (pagination == 2)
-index_widgets:
-# - category
-# - tagcloud
-# - archive
-
+# ===============
 # Widget behavior
+# ===============
 archive_type: 'monthly'
 show_count: false
 # How many posts display in Home page.
 recent_posts_limits: 5
 
+# ===============
 # Miscellaneous
+# ===============
 # Google Analytics ID
 google_analytics:
 gauges_analytics:
@@ -65,6 +71,11 @@ twitter:
 fb_admins:
 fb_app_id:
 
+# ===============
+# Comment system
+# ===============
+# Disqus comment system.
+disqus_shortname:
 # valine comment system. https://valine.js.org
 valine:
   enable: false # if you want use valine,please set this value is true

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,13 @@ rss: /atom.xml
 banner: "images/banner.jpg"
 # Subtitle of page top
 subtitle:
+# Header links with icon, specified links will appear at the top right corner of the page
+# Each name must correspond to the icon name of Fork Awesome
+# https://forkaweso.me/Fork-Awesome/icons/
+links:
+#  github: https://github.com/your_github_account
+#  twitter: https://twitter.com/your_twitter_account
+#  telegram: https://t.me/your_telegram_account
 
 # Content
 # "Read More" link at the bottom of excerpted articles. `false` to hide the link.
@@ -57,15 +64,6 @@ favicon: /favicon.png
 twitter:
 fb_admins:
 fb_app_id:
-
-# Header links
-# Header links with icon, specified links will appear at the top right corner of the page
-# Each name must correspond to the icon name of Fork Awesome
-# https://forkaweso.me/Fork-Awesome/icons/
-links:
-#  github: https://github.com/your_github_account
-#  twitter: https://twitter.com/your_twitter_account
-#  telegram: https://t.me/your_telegram_account
 
 # valine comment system. https://valine.js.org
 valine:

--- a/_config.yml
+++ b/_config.yml
@@ -1,31 +1,33 @@
 # Header
+# Navigation menu
 menu:
   Home: /
   Archives: /archives
+# RSS link
 rss: /atom.xml
+# Path of title banner image of page top
 banner: "images/banner.jpg"
+# Subtitle of page top
+subtitle:
 
 # Content
+# "Read More" link at the bottom of excerpted articles. `false` to hide the link.
 excerpt_link: Read More
+# Enable fancybox
 fancybox: true
 
-# # Footer
-# copyright: |-
-#   <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a></br>
-#   All website licensed under <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a></br>
-
 # Footer
-copyright:
-# Need help choosing? Please see...
-# https://creativecommons.org/choose/
-# https://choosealicense.com/
-# You can use html like below...
+# Display copyright notice in footer. Please see https://creativecommons.org/choose/ and https://choosealicense.com/
+# You can use html like below.
 # copyright: |-
 #   <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a></br>
 #   All website licensed under <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a></br>
+copyright:
 
 # Sidebar
+# Sidebar style. You can choose `left`, `right`, `bottom` or `false`.
 sidebar: right
+# Widgets displaying in sidebar
 widgets:
 - category
 - tag
@@ -42,15 +44,28 @@ index_widgets:
 # Widget behavior
 archive_type: 'monthly'
 show_count: false
+# How many posts display in Home page.
 recent_posts_limits: 5
 
 # Miscellaneous
+# Google Analytics ID
 google_analytics:
 gauges_analytics:
+# Favicon path
 favicon: /favicon.png
+# Twitter ID
 twitter:
 fb_admins:
 fb_app_id:
+
+# Header links
+# Header links with icon, specified links will appear at the top right corner of the page
+# Each name must correspond to the icon name of Fork Awesome
+# https://forkaweso.me/Fork-Awesome/icons/
+links:
+#  github: https://github.com/your_github_account
+#  twitter: https://twitter.com/your_twitter_account
+#  telegram: https://t.me/your_telegram_account
 
 # valine comment system. https://valine.js.org
 valine:


### PR DESCRIPTION
Currently, both the `_config.yml` and `README.md` of the landscape theme contain documentation for some configuration options, but neither is complete. I have moved all the configuration options and their explanations to `_config.yml`, and suggest that users directly copy this file to `_config.landscape.yml`. This way, it is more convenient to configure by referring to the hints inside, compared to consulting the README.