### PR TITLE
chore: use GitHub actions to deploy preview site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
           repository: hexojs/hexo-theme-unit-test
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: hexojs/hexo-starter
+          repository: hexojs/hexo-theme-unit-test
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3
@@ -43,18 +43,10 @@ jobs:
           node-version: "20"
       - name: Install Dependencies
         run: npm install
-      - name: Install hexo-tag-embed
-        run: npm install hexo-tag-embed
-      - name: Remove original theme
-        run: npm uninstall hexo-theme-landscape
       - name: Checkout latest theme
         uses: actions/checkout@v4
         with:
           path: themes/landscape
-      - uses: actions/checkout@v4
-        with:
-          repository: SukkaLab/hexo-many-posts
-          path: source/_posts/hexo-many-posts
       - name: Build with Hexo
         run: npx hexo g
       - name: Upload artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build with Hexo
         run: npx hexo g
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: Deploy preview site
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [$default-branch]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: hexojs/hexo-starter
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Dependencies
+        run: npm install
+      - name: Install hexo-tag-embed
+        run: npm install hexo-tag-embed
+      - name: Remove original theme
+        run: npm uninstall hexo-theme-landscape
+      - name: Checkout latest theme
+        uses: actions/checkout@v4
+        with:
+          path: themes/landscape
+      - uses: actions/checkout@v4
+        with:
+          repository: SukkaLab/hexo-many-posts
+          path: source/_posts/hexo-many-posts
+      - name: Build with Hexo
+        run: npx hexo g
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Currently, the landscape theme uses GitHub Pages (https://hexojs.github.io/hexo-theme-landscape/) for publishing previews, but this process requires manual intervention and has not been updated for many years. By switching to GitHub Actions, we can automate the build of the latest preview site.

