### PR TITLE
feat: read disqus_shortname from theme config

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -1,6 +1,6 @@
-<% if (config.disqus_shortname){ %>
+<% if (theme.disqus_shortname){ %>
 <script>
-  var disqus_shortname = '<%= config.disqus_shortname %>';
+  var disqus_shortname = '<%= theme.disqus_shortname %>';
   <% if (page.permalink){ %>
   var disqus_url = '<%= page.permalink %>';
   <% } %>

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -24,7 +24,7 @@
     </div>
     <footer class="article-footer">
       <a data-url="<%- post.permalink %>" data-id="<%= post._id %>" data-title="<%= post.title %>" class="article-share-link"><span class="fa fa-share"><%= __('share') %></span></a>
-      <% if (post.comments && config.disqus_shortname){ %>
+      <% if (post.comments && theme.disqus_shortname){ %>
         <a href="<%- post.permalink %>#disqus_thread" class="article-comment-link"><span class="fa fa-comment"><%= __('comment') %></span></a>
       <% } %>
       <% if (post.comments && theme.valine.enable && theme.valine.appId && theme.valine.appKey ){ %>
@@ -41,7 +41,7 @@
   <% } %>
 </article>
 
-<% if (!index && post.comments && config.disqus_shortname){ %>
+<% if (!index && post.comments && theme.disqus_shortname){ %>
 <section id="comments">
   <div id="disqus_thread">
     <noscript>Please enable JavaScript to view the <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>


### PR DESCRIPTION
In earlier versions of Hexo, themes needed to read the `disqus_shortname` from Hexo's `_config.yml` file as the configuration for the Disqus comment system. However, this option was deprecated around 2015 (https://github.com/hexojs/hexo-theme-unit-test/commit/8dd691e). Nowadays, many themes allow users to load different Disqus configuration options, and there are no unified regulations for this. Therefore, I plan to move the `disqus_shortname` option for the official Hexo theme from the Hexo configuration file to the theme configuration file.